### PR TITLE
Pass database number into JedisPool

### DIFF
--- a/src/main/resources/META-INF/spring/applicationContext.xml
+++ b/src/main/resources/META-INF/spring/applicationContext.xml
@@ -33,6 +33,7 @@
 		<constructor-arg value="${redis.port}" />
 		<constructor-arg value="${redis.timeout}" />
 		<constructor-arg value="${redis.password}" />
+		<constructor-arg value="${redis.database}" />
 	</bean>
 	
 	<bean id="failureDAO" class="net.greghaines.jesque.meta.dao.impl.FailureDAORedisImpl">


### PR DESCRIPTION
Fixes issue that the database number in the configuration file seems to be ignored