### PR TITLE
Use .getClass() rather than .class

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/failed.jsp
+++ b/src/main/webapp/WEB-INF/jsp/failed.jsp
@@ -39,7 +39,7 @@
 			<dt>Arguments</dt>
 			<dd><pre><c:out value="${(not empty job.payload) ? jsq:showArgs(job.payload.args) : 'null'}" /></pre></dd>
 			<dt>Exception</dt>
-			<dd><code><c:out value="${job.exception.class.name}" /></code></dd>
+			<dd><code><c:out value="${job.exception.getClass().name}" /></code></dd>
 			<dt>Error</dt>
 			<dd class="error">
 				<a href="#" class="backtrace"><c:out value="${job.exception.message}" /></a>


### PR DESCRIPTION
Workaround for Tomcat, where identifiers in expressions are checked "to ensure that they conform to the Java Language Specification for Java identifiers". Since "class" is a keyword, it causes an exception to be thrown.

See also: http://www.java-allandsundry.com/2012/11/jsp-expression-language-and-class.html